### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   build:
-    uses: valitydev/java-workflow/.github/workflows/maven-library-build.yml@v3
+    uses: valitydev/java-workflow/.github/workflows/maven-library-build.yml@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    uses: valitydev/java-workflow/.github/workflows/maven-library-deploy.yml@v3
+    uses: valitydev/java-workflow/.github/workflows/maven-library-deploy.yml@v4
     secrets:
       server-username: ${{ secrets.OSSRH_USERNAME }}
       server-password: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -208,8 +208,8 @@
                             <artifactId>maven-compiler-plugin</artifactId>
                             <version>3.15.0</version>
                             <configuration>
-                                <source>21</source>
-                                <target>21</target>
+                                <source>25</source>
+                                <target>25</target>
                                 <encoding>UTF-8</encoding>
                             </configuration>
                         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>java-service-dependencies</artifactId>
-    <version>1.0.38</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -36,15 +36,15 @@
 
     <properties>
         <woody.version>2.1.0</woody.version>
-        <woody-http-bridge.version>0.0.13</woody-http-bridge.version>
-        <shared-resources.version>3.0.1</shared-resources.version>
-        <damsel.version>1.674-368f05b</damsel.version>
+        <woody-http-bridge.version>0.0.15</woody-http-bridge.version>
+        <shared-resources.version>4.0.0</shared-resources.version>
+        <damsel.version>1.685-5c25c2e</damsel.version>
         <msgpack-proto.version>1.17-7481bb4</msgpack-proto.version>
         <nop-rolling.version>1.0.1</nop-rolling.version>
         <geck.verion>1.0.2</geck.verion>
         <db-common-lib.version>0.0.1</db-common-lib.version>
         <kafka-common-lib.version>0.0.3</kafka-common-lib.version>
-        <aws-msk-iam-auth.version>2.3.4</aws-msk-iam-auth.version>
+        <aws-msk-iam-auth.version>2.3.5</aws-msk-iam-auth.version>
     </properties>
 
     <dependencyManagement>
@@ -190,7 +190,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -206,10 +206,10 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
-                            <version>3.14.1</version>
+                            <version>3.15.0</version>
                             <configuration>
-                                <source>1.8</source>
-                                <target>1.8</target>
+                                <source>21</source>
+                                <target>21</target>
                                 <encoding>UTF-8</encoding>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
Обновил зависимости. Посчитал, что переезд на новую мажорную версию shared-resources + обновление минимальных версий для исходников с 1.8 до 25 заслуживает версии 2.0, так как потенциально может что-то сломать. 

Однако изменения не являются критичными, поскольку все эти версии можно переопределить на уровне настроек в pom-нике самого сервиса в прежние значения - из-за этого не стал делать бамп в эпике.

**Зачем обновил минимальные версии исходников до 25?** 

На мой взгляд корректно навязывать использование актуальной версии Java. Если же разработчик понимает, что ему нужна менее актуальная версия - он ее в явном виде переопределяет в помнике своего сервиса\библиотеки. Так проще найти сервисы и зависимости, которые используют неактуальную версию Java.